### PR TITLE
Add .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+github:
+  description: "Apache Otava (incubating) performs statistical analysis of performance test results. It finds change-points and notifies about possible performance regressions."
+  homepage: https://otava.apache.org/
+  features:
+    issues: true
+    projects: true
+    wiki: false
+  enabled_merge_buttons:
+    squash: true
+    merge: true
+    rebase: true
+  protected_branches:
+    master: {}

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 github:
-  description: "Apache Otava (incubating) performs statistical analysis of performance test results. It finds change-points and notifies about possible performance regressions."
+  description: "Change Detection for Continuous Performance Engineering"
   homepage: https://otava.apache.org/
   features:
     issues: true


### PR DESCRIPTION
This change will hopefully let us manage the "About" section of the GH page as well as other configs - labels, allowed PR merge strategies, etc.

See https://issues.apache.org/jira/browse/INFRA-26696  for context.