### PR TITLE
Update Dockerfile license (+ fix pre-commit-config)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,5 +92,4 @@ repos:
           - --license-filepath
           - ci-tools/license-templates/LICENSE.txt
           - --fuzzy-match-generates-todo
-        files: >
-          \.ini$|poetryw$|toxw$|Dockerfile.*$
+        files: \.ini$|poetryw$|toxw$|Dockerfile.*$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 FROM python:3.8.0-slim-buster
 # So that STDOUT/STDERR is printed


### PR DESCRIPTION
I noticed that the the pre-commit-config did not not update Dockerfile's license. I don't know why, but multiline "files" value does not pattern-match "Dockerfile", while same-line does.