### PR TITLE
Rename project name to apache-otava

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ version = "0.6.0+incubating"
 description = "Change Detection for Continuous Performance Engineering"
 authors = ["Apache Otava Developers <dev@otava.apache.org>"]
 include = ["DISCLAIMER"]
+packages = [{include = "otava"}]
 
 [tool.poetry.dependencies]
 dateparser = "^1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@
 # under the License.
 
 [tool.poetry]
-name = "otava"
+name = "apache-otava"
 version = "0.6.0+incubating"
 description = "Change Detection for Continuous Performance Engineering"
 authors = ["Apache Otava Developers <dev@otava.apache.org>"]


### PR DESCRIPTION
This change addresses RC feedback that project names typically contain prefix "apache-". For example, https://github.com/apache/airflow/blob/40789d677972a3d7d0827e5a12329879487f7926/pyproject.toml#L33