### PR TITLE
PyPI Project Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ also capable of comparing the level of performance recorded in two different git
 This can be used for example to validate a feature branch against the main branch, perhaps
 integrated with a pull request.
 
-See the documentation in [docs/README.md](docs/README.md).
+See the documentation in https://otava.apache.org/docs/overview/.
 
 ## Python Versions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,25 @@ name = "apache-otava"
 version = "0.6.0"
 description = "Apache Otava (Incubating): Change Detection for Continuous Performance Engineering"
 authors = ["Apache Otava (Incubating) <dev@otava.apache.org>"]
+maintainers = ["Apache Otava (Incubating) <dev@otava.apache.org>"]
 include = ["DISCLAIMER"]
 packages = [{ include = "otava" }]
+readme = "README.md"
+homepage = "https://otava.apache.org"
+repository = "https://github.com/apache/otava"
+license = "Apache-2.0"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+]
+
+[tool.poetry.urls]
+"Homepage" = "https://otava.apache.org"
+"Documentation" = "https://otava.apache.org/docs/overview"
+"Bug Tracker" = "https://github.com/apache/otava/issues"
+"Repository" = "https://github.com/apache/otava"
 
 [tool.poetry.dependencies]
 dateparser = "^1.0.0"


### PR DESCRIPTION
Fixes #66 

This is what the PyPI page would look like - https://test.pypi.org/project/apache-otava/. The is a test PyPI instance provided for such experiments, not a real release. Please ignore:
1. Me as the only maintainer - Test PyPI did not approve Otava organization yet and I did not want to block this fix on that approval.
2. Release version.