### PR TITLE
Use base image 3.8-slim-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM python:3.8.0-slim-buster
+FROM python:3.8-slim-bookworm
 # So that STDOUT/STDERR is printed
 ENV PYTHONUNBUFFERED="1"
 


### PR DESCRIPTION
Turns out, Python folks moved to a newer Debian for their images, so our current base image is broken.

Without this patch:

```
docker build -t "otava-poetry" --no-cache .
[+] Building 7.5s (8/11)                                                                                                                                                                          docker:colima
 => [internal] load build definition from Dockerfile                                                                                                                                                       0.0s
 => => transferring dockerfile: 2.02kB                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/python:3.8-slim-buster                                                                                                                                  2.9s
 => [internal] load .dockerignore                                                                                                                                                                          0.0s
 => => transferring context: 1.11kB                                                                                                                                                                        0.0s
 => [stage-0 1/7] FROM docker.io/library/python:3.8-slim-buster@sha256:8799b0564103a9f36cfb8a8e1c562e11a9a6f2e3bb214e2adc23982b36a04511                                                                    3.5s
 => => resolve docker.io/library/python:3.8-slim-buster@sha256:8799b0564103a9f36cfb8a8e1c562e11a9a6f2e3bb214e2adc23982b36a04511                                                                            0.0s
 => => sha256:3fe349e029970270c77c6cc4e8c8159d6390de76a4c30666e585e9ac57e54212 12.98MB / 12.98MB                                                                                                           1.4s
 => => sha256:8799b0564103a9f36cfb8a8e1c562e11a9a6f2e3bb214e2adc23982b36a04511 988B / 988B                                                                                                                 0.0s
 => => sha256:23d7a8ad83a5dc0487d65a89ab61aa618e5b5d6379b6e429e0459be999b5b8fd 1.37kB / 1.37kB                                                                                                             0.0s
 => => sha256:ebe69edfe405db3fc5cb36968a6f0359602992d8083c6674d9cf21af5362ca7e 6.88kB / 6.88kB                                                                                                             0.0s
 => => sha256:d191be7a3c9fa95847a482db8211b6f85b45096c7817fdad4d7661ee7ff1a421 25.92MB / 25.92MB                                                                                                           2.1s
 => => sha256:14aea17807c4c653827ca820a0526d96552bda685bf29293e8be90d1b05662f6 2.65MB / 2.65MB                                                                                                             0.5s
 => => sha256:7399277d91f4520aebebe70097c48af726818282fbbc79c1fb34b53f088eb090 243B / 243B                                                                                                                 1.0s
 => => sha256:35f10c4cf03d43a7afd688184e68c55cc3adc2049e78dffcc419a28f8ee8ac68 3.14MB / 3.14MB                                                                                                             2.5s
 => => extracting sha256:d191be7a3c9fa95847a482db8211b6f85b45096c7817fdad4d7661ee7ff1a421                                                                                                                  0.8s
 => => extracting sha256:14aea17807c4c653827ca820a0526d96552bda685bf29293e8be90d1b05662f6                                                                                                                  0.0s
 => => extracting sha256:3fe349e029970270c77c6cc4e8c8159d6390de76a4c30666e585e9ac57e54212                                                                                                                  0.2s
 => => extracting sha256:7399277d91f4520aebebe70097c48af726818282fbbc79c1fb34b53f088eb090                                                                                                                  0.0s
 => => extracting sha256:35f10c4cf03d43a7afd688184e68c55cc3adc2049e78dffcc419a28f8ee8ac68                                                                                                                  0.1s
 => [internal] load build context                                                                                                                                                                          0.1s
 => => transferring context: 60.18kB                                                                                                                                                                       0.0s
 => [stage-0 2/7] WORKDIR /srv/otava                                                                                                                                                                       0.1s
 => [stage-0 3/7] RUN groupadd --gid 8192 otava &&     useradd --uid 8192 --shell /bin/false --create-home --no-log-init --gid otava otava &&     chown otava:otava /srv/otava                             0.1s
 => ERROR [stage-0 4/7] RUN apt-get update --assume-yes &&     apt-get install -o 'Dpkg::Options::=--force-confnew' -y --force-yes -q     git     openssh-client     gcc     clang     build-essential     0.9s
------
 > [stage-0 4/7] RUN apt-get update --assume-yes &&     apt-get install -o 'Dpkg::Options::=--force-confnew' -y --force-yes -q     git     openssh-client     gcc     clang     build-essential     make     curl     virtualenv     && rm -rf /var/lib/apt/lists/*:
0.517 Ign:1 http://deb.debian.org/debian buster InRelease
0.680 Ign:2 http://deb.debian.org/debian-security buster/updates InRelease
0.778 Ign:3 http://deb.debian.org/debian buster-updates InRelease
0.794 Err:4 http://deb.debian.org/debian buster Release
0.794   404  Not Found [IP: 151.101.202.132 80]
0.811 Err:5 http://deb.debian.org/debian-security buster/updates Release
0.811   404  Not Found [IP: 151.101.202.132 80]
0.834 Err:6 http://deb.debian.org/debian buster-updates Release
0.834   404  Not Found [IP: 151.101.202.132 80]
0.840 Reading package lists...
0.851 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
0.851 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
0.851 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
------

 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 23)
Dockerfile:32
--------------------
  31 |     # Install System dependencies
  32 | >>> RUN apt-get update --assume-yes && \
  33 | >>>     apt-get install -o 'Dpkg::Options::=--force-confnew' -y --force-yes -q \
  34 | >>>     git \
  35 | >>>     openssh-client \
  36 | >>>     gcc \
  37 | >>>     clang \
  38 | >>>     build-essential \
  39 | >>>     make \
  40 | >>>     curl \
  41 | >>>     virtualenv \
  42 | >>>     && rm -rf /var/lib/apt/lists/*
  43 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update --assume-yes &&     apt-get install -o 'Dpkg::Options::=--force-confnew' -y --force-yes -q     git     openssh-client     gcc     clang     build-essential     make     curl     virtualenv     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```

With this patch:

```
docker build -t "otava-poetry" --no-cache .
[+] Building 59.6s (12/12) FINISHED                                                                                                                                                               docker:colima
 => [internal] load build definition from Dockerfile                                                                                                                                                       0.0s
 => => transferring dockerfile: 2.02kB                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/python:3.8-slim-bookworm                                                                                                                                1.1s
 => [internal] load .dockerignore                                                                                                                                                                          0.0s
 => => transferring context: 1.11kB                                                                                                                                                                        0.0s
 => [stage-0 1/7] FROM docker.io/library/python:3.8-slim-bookworm@sha256:1d52838af602b4b5a831beb13a0e4d073280665ea7be7f69ce2382f29c5a613f                                                                  2.9s
 => => resolve docker.io/library/python:3.8-slim-bookworm@sha256:1d52838af602b4b5a831beb13a0e4d073280665ea7be7f69ce2382f29c5a613f                                                                          0.0s
 => => sha256:14c9d9d199323cbf0a4c2347a8af85f2875c1f2c26a1558fd34dfca7a26cff22 29.16MB / 29.16MB                                                                                                           1.3s
 => => sha256:d847ad1879f2202660d37d9bedf1b8986116079d578b010e46b6917facf23dd5 3.33MB / 3.33MB                                                                                                             0.7s
 => => sha256:56d45b8e140401cb0bb97c76a062697a0502ff1928dad8483d76b108a38920d6 14.51MB / 14.51MB                                                                                                           1.6s
 => => sha256:1d52838af602b4b5a831beb13a0e4d073280665ea7be7f69ce2382f29c5a613f 10.41kB / 10.41kB                                                                                                           0.0s
 => => sha256:c37419b5a020178521c2e451f44424a2c0bdf3498ff29dd2c9c9d26feffa517b 1.75kB / 1.75kB                                                                                                             0.0s
 => => sha256:989bb9480c980a0e6722f366bf7dbf68bf6c097e66ed1fe450885989e5ef0b49 5.25kB / 5.25kB                                                                                                             0.0s
 => => sha256:0cd45dda32d5387b73cdb7755ea8f31eca0e250f2860b720e9e5155200321b67 249B / 249B                                                                                                                 1.3s
 => => extracting sha256:14c9d9d199323cbf0a4c2347a8af85f2875c1f2c26a1558fd34dfca7a26cff22                                                                                                                  0.8s
 => => extracting sha256:d847ad1879f2202660d37d9bedf1b8986116079d578b010e46b6917facf23dd5                                                                                                                  0.1s
 => => extracting sha256:56d45b8e140401cb0bb97c76a062697a0502ff1928dad8483d76b108a38920d6                                                                                                                  0.4s
 => => extracting sha256:0cd45dda32d5387b73cdb7755ea8f31eca0e250f2860b720e9e5155200321b67                                                                                                                  0.0s
 => [internal] load build context                                                                                                                                                                          0.1s
 => => transferring context: 60.18kB                                                                                                                                                                       0.1s
 => [stage-0 2/7] WORKDIR /srv/otava                                                                                                                                                                       0.1s
 => [stage-0 3/7] RUN groupadd --gid 8192 otava &&     useradd --uid 8192 --shell /bin/false --create-home --no-log-init --gid otava otava &&     chown otava:otava /srv/otava                             0.1s
 => [stage-0 4/7] RUN apt-get update --assume-yes &&     apt-get install -o 'Dpkg::Options::=--force-confnew' -y --force-yes -q     git     openssh-client     gcc     clang     build-essential     mak  29.0s
 => [stage-0 5/7] RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.8.3                                                                                                             13.6s
 => [stage-0 6/7] COPY --chown=otava:otava . /srv/otava                                                                                                                                                    0.1s
 => [stage-0 7/7] RUN  --mount=type=ssh     virtualenv --python python3.8 venv &&     . venv/bin/activate &&     poetry install -v &&     mkdir -p bin &&     ln -s ../venv/bin/otava /srv/otava/bin       9.0s
 => exporting to image                                                                                                                                                                                     3.8s
 => => exporting layers                                                                                                                                                                                    3.8s
 => => writing image sha256:6e90fa2acacb434b629d880641a8e8fcc0ade6abd85593119e2d2010333b6ff6                                                                                                               0.0s
 => => naming to docker.io/library/otava-poetry                                                                                                                                                            0.0s

 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 23)
```