### PR TITLE
Fix config parsing

### DIFF
--- a/otava/bigquery.py
+++ b/otava/bigquery.py
@@ -28,6 +28,8 @@ from otava.test_config import BigQueryTestConfig
 
 @dataclass
 class BigQueryConfig:
+    NAME = "bigquery"
+
     project_id: str
     dataset: str
     credentials: str

--- a/otava/config.py
+++ b/otava/config.py
@@ -127,13 +127,26 @@ class NestedYAMLConfigFileParser(configargparse.ConfigFileParser):
     Recasts values from YAML inferred types to strings as expected for CLI arguments.
     """
 
+    CLI_CONFIG_SECTIONS = [
+        GraphiteConfig.NAME,
+        GrafanaConfig.NAME,
+        SlackConfig.NAME,
+        PostgresConfig.NAME,
+        BigQueryConfig.NAME,
+    ]
+
     def parse(self, stream):
         yaml = YAML(typ="safe")
         config_data = yaml.load(stream)
         if config_data is None:
             return {}
+
         flattened_dict = {}
-        self._flatten_dict(config_data, flattened_dict)
+        for key, value in config_data.items():
+            if key in self.CLI_CONFIG_SECTIONS:
+                # Flatten only the config sections that correspond to CLI arguments
+                self._flatten_dict(value, flattened_dict, f"{key}-")
+            # Ignore other sections like 'templates' and 'tests' - they shouldn't become CLI arguments
         return flattened_dict
 
     def _flatten_dict(self, nested_dict, flattened_dict, prefix=''):

--- a/otava/grafana.py
+++ b/otava/grafana.py
@@ -26,6 +26,8 @@ from requests.exceptions import HTTPError
 
 @dataclass
 class GrafanaConfig:
+    NAME = "grafana"
+
     url: str
     user: str
     password: str

--- a/otava/graphite.py
+++ b/otava/graphite.py
@@ -29,6 +29,8 @@ from otava.util import parse_datetime
 
 @dataclass
 class GraphiteConfig:
+    NAME = "graphite"
+
     url: str
 
     @staticmethod

--- a/otava/main.py
+++ b/otava/main.py
@@ -518,6 +518,7 @@ def create_otava_cli_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Hunts performance regressions in Fallout results",
         parents=[config.create_config_parser()],
+        config_file_parser_class=config.NestedYAMLConfigFileParser,
         allow_abbrev=False,  # required for correct parsing of nested values from config file
     )
 

--- a/otava/postgres.py
+++ b/otava/postgres.py
@@ -27,6 +27,8 @@ from otava.test_config import PostgresTestConfig
 
 @dataclass
 class PostgresConfig:
+    NAME = "postgres"
+
     hostname: str
     port: int
     username: str

--- a/otava/slack.py
+++ b/otava/slack.py
@@ -34,6 +34,8 @@ class NotificationError(Exception):
 
 @dataclass
 class SlackConfig:
+    NAME = "slack"
+
     bot_token: str
 
     @staticmethod


### PR DESCRIPTION
This fixes #88 . Now, the CLI parser ignores sections of the config that do not have their equivalents in the CLI.