### PR TITLE
fix: move --update-<importer> args into their service option groups

### DIFF
--- a/otava/config.py
+++ b/otava/config.py
@@ -182,6 +182,20 @@ def add_service_option_groups(parser) -> None:
     BigQueryConfig.add_parser_args(parser.add_argument_group('BigQuery Options', 'Options for BigQuery configuration'))
 
 
+def argument_group(parser, title: str):
+    """Return the existing argument group named `title` on `parser`.
+
+    Subparsers inherit the service option groups from the shared parent parser,
+    so options that belong to a service must be added to that service's group
+    instead of the parser's default group. Falls back to creating the group if
+    it is not present.
+    """
+    for group in parser._action_groups:
+        if group.title == title:
+            return group
+    return parser.add_argument_group(title)
+
+
 def create_subparser_parent() -> configargparse.ArgumentParser:
     """Create a parent parser for subparsers that accepts --config-file and service options."""
     parent = configargparse.ArgumentParser(add_help=False)

--- a/otava/main.py
+++ b/otava/main.py
@@ -486,17 +486,17 @@ def create_otava_cli_parser() -> argparse.ArgumentParser:
         parents=[subparser_parent],
     )
     analyze_parser.add_argument("tests", help="name of the test or group of the tests", nargs="+")
-    analyze_parser.add_argument(
+    config.argument_group(analyze_parser, "Grafana Options").add_argument(
         "--update-grafana",
         help="Update Grafana dashboards with appropriate annotations of change points",
         action="store_true",
     )
-    analyze_parser.add_argument(
+    config.argument_group(analyze_parser, "PostgreSQL Options").add_argument(
         "--update-postgres",
         help="Update PostgreSQL database results with change points",
         action="store_true",
     )
-    analyze_parser.add_argument(
+    config.argument_group(analyze_parser, "BigQuery Options").add_argument(
         "--update-bigquery",
         help="Update BigQuery database results with change points",
         action="store_true",

--- a/tests/cli_help_test.py
+++ b/tests/cli_help_test.py
@@ -172,9 +172,6 @@ options:
   -h, --help            show this help message and exit
   --config-file CONFIG_FILE
                         Otava config file path [env var: OTAVA_CONFIG]
-  --update-grafana      Update Grafana dashboards with appropriate annotations of change points
-  --update-postgres     Update PostgreSQL database results with change points
-  --update-bigquery     Update BigQuery database results with change points
   --notify-slack NOTIFY_SLACK [NOTIFY_SLACK ...]
                         Send notification containing a summary of change points to given Slack
                         channels
@@ -233,6 +230,7 @@ Grafana Options:
                         Grafana server user [env var: GRAFANA_USER]
   --grafana-password GRAFANA_PASSWORD
                         Grafana server password [env var: GRAFANA_PASSWORD]
+  --update-grafana      Update Grafana dashboards with appropriate annotations of change points
 
 Slack Options:
   Options for Slack configuration
@@ -254,6 +252,7 @@ PostgreSQL Options:
                         PostgreSQL password [env var: POSTGRES_PASSWORD]
   --postgres-database POSTGRES_DATABASE
                         PostgreSQL database name [env var: POSTGRES_DATABASE]
+  --update-postgres     Update PostgreSQL database results with change points
 
 BigQuery Options:
   Options for BigQuery configuration
@@ -264,6 +263,7 @@ BigQuery Options:
                         BigQuery dataset [env var: BIGQUERY_DATASET]
   --bigquery-credentials BIGQUERY_CREDENTIALS
                         BigQuery credentials file [env var: BIGQUERY_VAULT_SECRET]
+  --update-bigquery     Update BigQuery database results with change points
 
  In general, command-line values override environment variables which override defaults.
 """


### PR DESCRIPTION
Closes #120

`--update-grafana`, `--update-postgres` and `--update-bigquery` are added directly to the `analyze` subparser, so argparse lists them under the generic `options:` section instead of next to the service options they configure.

The subparser already inherits the Grafana/PostgreSQL/BigQuery groups from the shared parent parser, so this adds a small `config.argument_group()` helper that looks up an existing group by title and registers each flag on the matching group. Parsing behaviour is unchanged — only the help layout differs. The golden help assertions in `tests/cli_help_test.py` are updated accordingly and fail without the fix.
