### PR TITLE
docs: add Sphinx documentation build

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -59,6 +59,25 @@ jobs:
       - name: Run tox
         run: tox -e py
 
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: "3.12"
+          prune-cache: true
+
+      - name: Build documentation
+        run: uv run --with-requirements docs/requirements.txt sphinx-build -W --keep-going -b html docs docs/_build/html
+
   docker-build:
     runs-on: ubuntu-latest
     needs: build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,20 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# IntelliJ IDEA files
-.idea/
-*.iml
+version: 2
 
-# pyenv version info
-.python-version
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
 
-# Python 3 cache
-__pycache__/
+sphinx:
+  configuration: docs/conf.py
 
-# Other Python dev dirs
-build/
-dist/
-venv/
-.tox/
-.docker/
-docs/_build/
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/BASICS.md
+++ b/docs/BASICS.md
@@ -79,7 +79,7 @@ The results are simply concatenated.
 
 > [!TIP]
 > See [otava.yaml](../examples/csv/config/otava.yaml) for the full
-> example configuration and [local_samples.csv](../examples/csv/data/local_samples.csv)
+> example configuration and [local_sample.csv](../examples/csv/data/local_sample.csv)
 > for the data.
 
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,20 +17,34 @@
  under the License.
  -->
 
-# Table of Contents
+# Apache Otava Documentation
 
-## Getting Started
-- [Installation](INSTALL.md)
-- [Getting Started](GETTING_STARTED.md)
-- [Contributing](CONTRIBUTING.md)
+```{toctree}
+:maxdepth: 2
+:caption: Getting Started
 
-## Basics
-- [Basics](BASICS.md)
+INSTALL
+GETTING_STARTED
+CONTRIBUTING
+```
 
-## Data Sources
-- [Graphite](GRAPHITE.md)
-- [PostgreSQL](POSTGRESQL.md)
-- [BigQuery](BIG_QUERY.md)
-- [CSV](CSV.md)
-- [InfluxDB](INFLUXDB.md)
-- [Annotating Change Points in Grafana](GRAFANA.md)
+```{toctree}
+:maxdepth: 2
+:caption: Using Otava
+
+BASICS
+CSV
+GRAPHITE
+POSTGRESQL
+BIG_QUERY
+INFLUXDB
+GRAFANA
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Reference
+
+MATH
+RELEASE
+```

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -39,7 +39,7 @@ Please remember, that the act of publishing software has both legal and policy s
 ### What is in Apache Otava Release
 
 Apache Otava release consists of:
-* ASF source zips archived on [dist.apache.org](dist.apache.org).
+* ASF source zips archived on [dist.apache.org](https://dist.apache.org).
 * PyPI wheels published to [pypi.org](https://pypi.org/project/apache-otava/).
 * Docker images published to [Dockerhub](https://hub.docker.com/r/apache/otava).
 * Release tag on [GitHub](https://github.com/apache/otava/releases).
@@ -64,7 +64,7 @@ Deciding to release and selecting a Release Manager is the first step of the rel
 Anybody can propose a release on the dev@ mailing list, giving a solid argument and nominating a committer as the Release Manager (including themselves). There’s no formal process, no vote requirements, and no timing requirements. Any objections should be resolved by consensus before starting the release.
 In general, the community prefers to have a rotating set of 3-5 Release Managers. Keeping a small core set of managers allows enough people to build expertise in this area and improve processes over time, without Release Managers needing to re-learn the processes for each release. That said, if you are a committer interested in serving the community in this way, please reach out to the community on the dev@ mailing list.
 
-#### Checklist to proceed to the next step
+### Checklist to proceed to the next step
 
 1. Community agrees to release
 2. Community selects a Release Manager

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,20 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# IntelliJ IDEA files
-.idea/
-*.iml
+project = "Apache Otava (Incubating)"
+copyright = "2026, The Apache Software Foundation"
+author = "The Apache Software Foundation"
 
-# pyenv version info
-.python-version
+extensions = ["myst_parser"]
+root_doc = "README"
+source_suffix = {".md": "markdown"}
+exclude_patterns = ["_build"]
 
-# Python 3 cache
-__pycache__/
+myst_enable_extensions = ["colon_fence", "deflist", "dollarmath"]
+myst_heading_anchors = 3
 
-# Other Python dev dirs
-build/
-dist/
-venv/
-.tox/
-.docker/
-docs/_build/
+html_theme = "sphinx_rtd_theme"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,20 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# IntelliJ IDEA files
-.idea/
-*.iml
-
-# pyenv version info
-.python-version
-
-# Python 3 cache
-__pycache__/
-
-# Other Python dev dirs
-build/
-dist/
-venv/
-.tox/
-.docker/
-docs/_build/
+Sphinx>=8.1,<9
+myst-parser>=4,<5
+sphinx-rtd-theme>=3,<4


### PR DESCRIPTION
Remaining external step: an Apache maintainer can connect/configure the ReadTheDocs project or custom domain.

  - Added Sphinx + MyST configuration: `docs/conf.py`
  - Added ReadTheDocs setup and documentation
    dependencies: `.readthedocs.yaml`, `docs/requirements.txt`

  - Converted the docs table of contents to MyST/Sphinx navigation:
    `docs/README.md`

  - Added a strict documentation-build CI job and ignored generated
    HTML output.

  - Fixed three existing docs issues exposed by strict Sphinx
    validation.

Validation passed:

```uv run --with-requirements docs/requirements.txt sphinx-build -W --keep-going -b html docs docs/_build/html```