### PR TITLE
Update Docker actions allowed by ASF CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -66,10 +66,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Move the Docker setup actions used by the docker-build job to SHAs currently listed in apache/infrastructure-actions. The previous setup-buildx ref is no longer in the allowlist, and the setup-qemu ref expires on 2026-08-19, which can cause GitHub Actions startup failures before any jobs are created.